### PR TITLE
Launcher Improvements

### DIFF
--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -130,7 +130,7 @@ fi
 if [ ! -z $IMAGE ]; then
   IMAGE_DISK="-drive file=$IMAGE,if=none,id=disk0,format=qcow2,snapshot=on \
     -device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=on \
-    -device scsi-hd,drive=disk0,bootindex=0"
+    -device scsi-hd,drive=disk0"
 fi
 
 if [ "$EUID" -ne 0 ]; then

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -11,7 +11,13 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 : "${QEMU:=qemu-system-x86_64}"
 : "${IGVM:=$SCRIPT_DIR/../bin/coconut-qemu.igvm}"
 
-C_BIT_POS=$("$SCRIPT_DIR/../utils/cbit" || true)
+C_BIT_UTIL="$SCRIPT_DIR/../utils/cbit"
+if [ ! -x "$C_BIT_UTIL" ]; then
+  echo "C-Bit util not found. Trying to build it..."
+  make -C "$SCRIPT_DIR/.." utils/cbit || true
+fi
+
+C_BIT_POS=$("$C_BIT_UTIL" || true)
 COM1_SERIAL="-serial stdio" # console
 COM2_SERIAL="-serial null"  # debug
 COM3_SERIAL="-serial null"  # used by hyper-v

--- a/scripts/launch_guest.sh
+++ b/scripts/launch_guest.sh
@@ -70,6 +70,10 @@ while [[ $# -gt 0 ]]; do
       CGS=nocc
       shift
       ;;
+    --)
+      shift
+      break
+      ;;
     -*|--*)
       echo "Unknown option $1"
       exit 1
@@ -176,4 +180,5 @@ $SUDO_CMD \
     $COM4_SERIAL \
     $QEMU_EXIT_DEVICE \
     $QEMU_TEST_IO_DEVICE \
-    $STATE_DEVICE
+    $STATE_DEVICE \
+    "$@"


### PR DESCRIPTION
Here are some little convenience improvements for the QEMU launcher script.

1. Pass-through of arbitrary arguments to the QEMU call. This is convenient for debugging, for example.
2. Don't set the boot device explicitly. This allows booting from other devices for testing/experiments.
3. Automatically build the cbit util, if it does not exist. (Very handy, because I always forget to build it!)

## Summary by Sourcery

Enhance the QEMU launcher script by forwarding extra arguments to QEMU, removing a hard-coded boot device, and auto-building the cbit utility if it’s not present.

Enhancements:
- Allow passing arbitrary arguments to the QEMU invocation via a “--” delimiter and appending $@
- Remove the explicit bootindex setting on the disk device to enable booting from other devices
- Detect when the cbit utility is missing and automatically build it before use