### PR TITLE
libcrt fixes

### DIFF
--- a/libtcgtpm/deps/libcrt/Makefile
+++ b/libtcgtpm/deps/libcrt/Makefile
@@ -10,6 +10,7 @@ CFLAGS += -I./include -nostdinc -nostdlib -mno-red-zone
 CFLAGS += -m64 -march=x86-64 -mno-sse2 -fPIE
 CFLAGS += -fno-stack-protector
 CFLAGS += -ffreestanding
+CFLAGS += -Wall -Werror
 
 CC = gcc
 

--- a/libtcgtpm/deps/libcrt/include/libcrt.h
+++ b/libtcgtpm/deps/libcrt/include/libcrt.h
@@ -62,6 +62,8 @@
 #define __NEED_blksize_t
 #define __NEED_blkcnt_t
 
+#define __NEED_useconds_t
+
 #include <bits/alltypes.h>
 
 // errno.h
@@ -145,8 +147,8 @@ int issetugid(void);
 
 int getentropy(void *buffer, size_t length);
 long syscall(long number, ...);
-int usleep(unsigned usec);
-int sleep(unsigned usec);
+int usleep(useconds_t usec);
+unsigned int sleep(unsigned int seconds);
 
 // stdio.h
 

--- a/libtcgtpm/deps/libcrt/src/stdlib/qsort.c
+++ b/libtcgtpm/deps/libcrt/src/stdlib/qsort.c
@@ -62,6 +62,7 @@ static void cycle(size_t width, unsigned char* ar[], int n)
 		}
 		width -= l;
 	}
+	ar[n] = NULL;
 }
 
 /* shl() and shr() need n > 0 */

--- a/libtcgtpm/deps/libcrt/src/string/memchr.c
+++ b/libtcgtpm/deps/libcrt/src/string/memchr.c
@@ -8,7 +8,7 @@
 #define ALIGN (sizeof(size_t)-1)
 #define ONES ((size_t)-1/UCHAR_MAX)
 #define HIGHS (ONES * (UCHAR_MAX/2+1))
-#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+#define HASZERO(x) (((x)-ONES) & ~(x) & HIGHS)
 
 void *memchr(const void *src, int c, size_t n)
 {

--- a/libtcgtpm/deps/libcrt/src/string/stpcpy.c
+++ b/libtcgtpm/deps/libcrt/src/string/stpcpy.c
@@ -7,7 +7,7 @@
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)
 #define HIGHS (ONES * (UCHAR_MAX/2+1))
-#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+#define HASZERO(x) (((x)-ONES) & ~(x) & HIGHS)
 
 char *__stpcpy(char *restrict d, const char *restrict s)
 {

--- a/libtcgtpm/deps/libcrt/src/string/stpncpy.c
+++ b/libtcgtpm/deps/libcrt/src/string/stpncpy.c
@@ -7,7 +7,7 @@
 #define ALIGN (sizeof(size_t)-1)
 #define ONES ((size_t)-1/UCHAR_MAX)
 #define HIGHS (ONES * (UCHAR_MAX/2+1))
-#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+#define HASZERO(x) (((x)-ONES) & ~(x) & HIGHS)
 
 char *__stpncpy(char *restrict d, const char *restrict s, size_t n)
 {

--- a/libtcgtpm/deps/libcrt/src/string/strchrnul.c
+++ b/libtcgtpm/deps/libcrt/src/string/strchrnul.c
@@ -7,7 +7,7 @@
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)
 #define HIGHS (ONES * (UCHAR_MAX/2+1))
-#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+#define HASZERO(x) (((x)-ONES) & ~(x) & HIGHS)
 
 char *__strchrnul(const char *s, int c)
 {

--- a/libtcgtpm/deps/libcrt/src/string/strlen.c
+++ b/libtcgtpm/deps/libcrt/src/string/strlen.c
@@ -7,7 +7,7 @@
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)
 #define HIGHS (ONES * (UCHAR_MAX/2+1))
-#define HASZERO(x) ((x)-ONES & ~(x) & HIGHS)
+#define HASZERO(x) (((x)-ONES) & ~(x) & HIGHS)
 
 size_t strlen(const char *s)
 {

--- a/libtcgtpm/deps/libcrt/src/stub.c
+++ b/libtcgtpm/deps/libcrt/src/stub.c
@@ -136,16 +136,16 @@ long syscall(long number, ...)
     return -1;
 }
 
-int usleep(unsigned usec)
+int usleep(useconds_t usec)
 {
     NOT_IMPLEMENTED;
     return -1;
 }
 
-int sleep(unsigned usec)
+unsigned int sleep(unsigned int seconds)
 {
     NOT_IMPLEMENTED;
-    return -1;
+    return seconds;
 }
 
 int timezone = 0;


### PR DESCRIPTION
Fix some compiler warnings in the C library of the vTPM and turn
on -Werror for it.

- **libtcgtpm: libcrt: Aling sleep functions with POSIX**
- **libtcgtpm: libcrt: Fix compiler warnings**
- **libtcgtpm: libcrt: Fix compiler warning in qsort**
- **libtcgtpm: libcrt: Trun on -Werror -Wall**

## Summary by Sourcery

Enforce strict compilation in libcrt by enabling warnings-as-errors and resolve various compiler warnings through POSIX signature alignment, macro fixes, and implementation adjustments

Bug Fixes:
- Align usleep and sleep signatures with POSIX by introducing useconds_t and updating both prototypes and stub implementations
- Adjust HASZERO macro parentheses in multiple string routines to resolve compiler warnings
- Insert missing null sentinel in qsort implementation to fix out-of-bounds warning
- Correct sleep stub return value to match updated unsigned return type

Build:
- Enable -Wall and -Werror flags in libcrt Makefile