### PR TITLE
virtio-drivers: Add missing SAFETY comments

### DIFF
--- a/virtio-drivers/src/hal/fake.rs
+++ b/virtio-drivers/src/hal/fake.rs
@@ -17,11 +17,14 @@ use zerocopy::FromZeros;
 pub struct FakeHal;
 
 /// Fake HAL implementation for use in unit tests.
+///
+/// # Safety
+/// Follows the safety requirements outlined for the Hal trait.
 unsafe impl Hal for FakeHal {
     fn dma_alloc(pages: usize, _direction: BufferDirection) -> (PhysAddr, NonNull<u8>) {
         assert_ne!(pages, 0);
         let layout = Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap();
-        // Safe because the size and alignment of the layout are non-zero.
+        // SAFETY: Safe because the size and alignment of the layout are non-zero.
         let ptr = unsafe { alloc_zeroed(layout) };
         if let Some(ptr) = NonNull::new(ptr) {
             (ptr.as_ptr() as PhysAddr, ptr)
@@ -30,10 +33,14 @@ unsafe impl Hal for FakeHal {
         }
     }
 
+    /// # Safety
+    ///
+    /// Caller must ensure vaddr was returned by a previous call to dma_alloc and the
+    /// number of pages is the same.
     unsafe fn dma_dealloc(_paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
         assert_ne!(pages, 0);
         let layout = Layout::from_size_align(pages * PAGE_SIZE, PAGE_SIZE).unwrap();
-        // Safe because the layout is the same as was used when the memory was allocated by
+        // SAFETY: Safe because the layout is the same as was used when the memory was allocated by
         // `dma_alloc` above.
         unsafe {
             dealloc(vaddr.as_ptr(), layout);
@@ -41,16 +48,24 @@ unsafe impl Hal for FakeHal {
         0
     }
 
+    /// # Safety
+    ///
+    /// Caller must ensure paddr is a valid MMIO region of the given size.
     unsafe fn mmio_phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
         NonNull::new(paddr as _).unwrap()
     }
 
+    /// # Safety
+    ///
+    /// The buffer must be a valid pointer to a non-empty memory range which will not be accessed by
+    /// any other thread for the duration of this method call.
     unsafe fn share(buffer: NonNull<[u8]>, direction: BufferDirection) -> PhysAddr {
         assert_ne!(buffer.len(), 0);
         // To ensure that the driver is handling and unsharing buffers properly, allocate a new
         // buffer and copy to it if appropriate.
         let mut shared_buffer = <[u8]>::new_box_zeroed_with_elems(buffer.len()).unwrap();
         if let BufferDirection::DriverToDevice | BufferDirection::Both = direction {
+            // SAFETY: Safe because shared_buffer was allocated just above with the correct size
             unsafe {
                 buffer
                     .as_ptr()
@@ -63,10 +78,17 @@ unsafe impl Hal for FakeHal {
         virt_to_phys(vaddr)
     }
 
+    /// # Safety
+    ///
+    /// The buffer must be a valid pointer to a non-empty memory range which will not be accessed by
+    /// any other thread for the duration of this method call. The `paddr` must be the value
+    /// previously returned by the corresponding `share` call.
     unsafe fn unshare(paddr: PhysAddr, buffer: NonNull<[u8]>, direction: BufferDirection) {
         assert_ne!(buffer.len(), 0);
         assert_ne!(paddr, 0);
         let vaddr = phys_to_virt(paddr);
+        // SAFETY: Caller has to ensure that paddr was returned by a matching call to share()
+        // above.
         let shared_buffer = unsafe {
             Box::from_raw(ptr::slice_from_raw_parts_mut(
                 vaddr as *mut u8,
@@ -74,6 +96,8 @@ unsafe impl Hal for FakeHal {
             ))
         };
         if let BufferDirection::DeviceToDriver | BufferDirection::Both = direction {
+            // SAFETY: Caller has to ensure that paddr was returned by a matching call to share()
+            // above.
             unsafe {
                 buffer
                     .as_ptr()

--- a/virtio-drivers/src/queue.rs
+++ b/virtio-drivers/src/queue.rs
@@ -1000,8 +1000,8 @@ mod tests {
     #[test]
     fn queue_too_big() {
         let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
-        // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
         let mut transport =
+            // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
             unsafe { MmioTransport::<FakeHal>::new(NonNull::from(&mut header)) }.unwrap();
         assert_eq!(
             VirtQueue::<FakeHal, 8>::new(&mut transport, 0, false, false).unwrap_err(),
@@ -1012,8 +1012,8 @@ mod tests {
     #[test]
     fn queue_already_used() {
         let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
-        // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
         let mut transport =
+            // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
             unsafe { MmioTransport::<FakeHal>::new(NonNull::from(&mut header)) }.unwrap();
         VirtQueue::<FakeHal, 4>::new(&mut transport, 0, false, false).unwrap();
         assert_eq!(
@@ -1025,8 +1025,8 @@ mod tests {
     #[test]
     fn add_empty() {
         let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
-        // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
         let mut transport =
+            // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
             unsafe { MmioTransport::<FakeHal>::new(NonNull::from(&mut header)) }.unwrap();
         let mut queue = VirtQueue::<FakeHal, 4>::new(&mut transport, 0, false, false).unwrap();
         assert_eq!(
@@ -1039,8 +1039,8 @@ mod tests {
     #[test]
     fn add_too_many() {
         let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
-        // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
         let mut transport =
+            // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
             unsafe { MmioTransport::<FakeHal>::new(NonNull::from(&mut header)) }.unwrap();
         let mut queue = VirtQueue::<FakeHal, 4>::new(&mut transport, 0, false, false).unwrap();
         assert_eq!(queue.available_desc(), 4);
@@ -1054,14 +1054,16 @@ mod tests {
     #[test]
     fn add_buffers() {
         let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
-        // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
         let mut transport =
+            // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
             unsafe { MmioTransport::<FakeHal>::new(NonNull::from(&mut header)) }.unwrap();
         let mut queue = VirtQueue::<FakeHal, 4>::new(&mut transport, 0, false, false).unwrap();
         assert_eq!(queue.available_desc(), 4);
 
         // Add a buffer chain consisting of two device-readable parts followed by two
         // device-writable parts.
+        // SAFETY: Both buffers are at least valid for the duration of the call to add(). The
+        // buffers are not accessed otherwise during this test case.
         let token = unsafe { queue.add(&[&[1, 2], &[3]], &mut [&mut [0, 0], &mut [0]]) }.unwrap();
 
         assert_eq!(queue.available_desc(), 0);
@@ -1119,14 +1121,16 @@ mod tests {
         use core::ptr::slice_from_raw_parts;
 
         let mut header = VirtIOHeader::make_fake_header(MODERN_VERSION, 1, 0, 0, 4);
-        // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
         let mut transport =
+            // SAFETY: `header` was created by `VirtIOHeader::make_fake_header()`.
             unsafe { MmioTransport::<FakeHal>::new(NonNull::from(&mut header)) }.unwrap();
         let mut queue = VirtQueue::<FakeHal, 4>::new(&mut transport, 0, true, false).unwrap();
         assert_eq!(queue.available_desc(), 4);
 
         // Add a buffer chain consisting of two device-readable parts followed by two
         // device-writable parts.
+        // SAFETY: Both buffers are at least valid for the duration of the call to add(). The
+        // buffers are not accessed otherwise during this test case.
         let token = unsafe { queue.add(&[&[1, 2], &[3]], &mut [&mut [0, 0], &mut [0]]) }.unwrap();
 
         assert_eq!(queue.available_desc(), 4);
@@ -1187,6 +1191,7 @@ mod tests {
 
         // Check that the avail ring's flag is zero by default.
         assert_eq!(
+            // SAFETY: queue was created above; we can assume that its `avail` field is readable.
             unsafe { (*queue.avail.as_ptr()).flags.load(Ordering::Acquire) },
             0x0
         );
@@ -1195,6 +1200,7 @@ mod tests {
 
         // Check that the avail ring's flag is 1 after `disable_dev_notify`.
         assert_eq!(
+            // SAFETY: queue was created above; we can assume that its `avail` field is readable.
             unsafe { (*queue.avail.as_ptr()).flags.load(Ordering::Acquire) },
             0x1
         );
@@ -1203,6 +1209,7 @@ mod tests {
 
         // Check that the avail ring's flag is 0 after `enable_dev_notify`.
         assert_eq!(
+            // SAFETY: queue was created above; we can assume that its `avail` field is readable.
             unsafe { (*queue.avail.as_ptr()).flags.load(Ordering::Acquire) },
             0x0
         );
@@ -1227,6 +1234,8 @@ mod tests {
         let mut queue = VirtQueue::<FakeHal, 4>::new(&mut transport, 0, false, false).unwrap();
 
         // Add a buffer chain with a single device-readable part.
+        // SAFETY: Both buffers are at least valid for the duration of the call to add(). The
+        // buffers are not accessed otherwise during this test case.
         unsafe { queue.add(&[&[42]], &mut []) }.unwrap();
 
         // Check that the transport would be notified.
@@ -1262,6 +1271,8 @@ mod tests {
         let mut queue = VirtQueue::<FakeHal, 4>::new(&mut transport, 0, false, true).unwrap();
 
         // Add a buffer chain with a single device-readable part.
+        // SAFETY: Both buffers are at least valid for the duration of the call to add(). The
+        // buffers are not accessed otherwise during this test case.
         assert_eq!(unsafe { queue.add(&[&[42]], &mut []) }.unwrap(), 0);
 
         // Check that the transport would be notified.
@@ -1280,6 +1291,8 @@ mod tests {
         assert!(!queue.should_notify());
 
         // Add another buffer chain.
+        // SAFETY: Both buffers are at least valid for the duration of the call to add(). The
+        // buffers are not accessed otherwise during this test case.
         assert_eq!(unsafe { queue.add(&[&[42]], &mut []) }.unwrap(), 1);
 
         // Check that the transport should be notified again now.


### PR DESCRIPTION
Add missing SAFETY comments in the virtio-drivers code.
In many cases the comments were already there, simply missing the
"SAFETY" keyword.

## Summary by Sourcery

Add missing SAFETY comments to clarify safety requirements for unsafe operations in virtio-drivers

Enhancements:
- Add missing SAFETY annotations to unsafe MmioTransport and VirtQueue calls in queue tests
- Add SAFETY documentation comments to unsafe Hal trait methods in the FakeHal implementation